### PR TITLE
Add REG_QWORD and REG_QWORD_LITTLE_ENDIAN

### DIFF
--- a/winregistry/winregistry.py
+++ b/winregistry/winregistry.py
@@ -39,7 +39,11 @@ WINREG_TYPES = ['REG_NONE',              # 0 == winreg.REG_NONE
                                          # 9 == winreg.REG_FULL_RESOURCE_DESCRIPTOR
                 'REG_FULL_RESOURCE_DESCRIPTOR',
                 # 10 == winreg.REG_RESOURCE_REQUIREMENTS_LIST:
-                'REG_RESOURCE_REQUIREMENTS_LIST']
+                'REG_RESOURCE_REQUIREMENTS_LIST',
+                'REG_QWORD'             # 11 == winreg.REG_QWORD
+                                         # 11 == winreg.REG_QWORD_LITTLE_ENDIAN
+                # 'REG_QWORD_LITTLE_ENDIAN'
+]
 
 SHORT_ROOTS = {
     'HKCR': 'HKEY_CLASSES_ROOT',


### PR DESCRIPTION
Add needed support of these data types (64 bit numbers) as per https://docs.microsoft.com/en-us/windows/desktop/sysinfo/registry-value-types

If accessing a registry value with this type, the existing code crashes.