### PR TITLE
Write REG_BINARY Values from  a Hex String

### DIFF
--- a/winregistry/winregistry.py
+++ b/winregistry/winregistry.py
@@ -102,7 +102,6 @@ class WinRegistry:
             new_value = bytes.fromhex(hex_string)
         else:
             new_value = value
-        print("type=", reg_type, " name=", name, " Value=", new_value)
         SetValueEx(handle, name, 0, reg_type.value, new_value)
 
     def delete_entry(


### PR DESCRIPTION
When looking for an alternative to AutoIt RegWrite we found this site-package was useful and did all that we wanted except did not appear to work when we wanted to write REG_BINARY values to the registry.  We have been able to modify the existing write_entry() to allow us to write Hex Strings the same way we used to in AutoIt RegWrite using Robotframework keywords.