### PR TITLE
fix: critical findings from package audit (C1, C3, C5)

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -8,6 +8,11 @@
   jobs:
     build:
       runs-on: ubuntu-latest
+      environment:
+        name: pypi
+        url: https://pypi.org/p/winregistry
+      permissions:
+        id-token: write
       steps:
         - uses: actions/checkout@v4
         - name: Extract version from tag
@@ -21,4 +26,4 @@
         - run: uv python install 3.12
         - run: uv sync --all-extras --dev
         - run: uv build
-        - run: uv publish --username __token__ --password ${{ secrets.PYPI_PASS }}
+        - run: uv publish --trusted-publishing always

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # WinRegistry
 
-[![PyPI](https://img.shields.io/pypi/v/winregistry.svg)](https://pypi.python.org/pypi/winregistry)
-[![PyPI](https://img.shields.io/pypi/dm/winregistry.svg)](https://pypi.python.org/pypi/winregistry)
+[![PyPI version](https://img.shields.io/pypi/v/winregistry.svg)](https://pypi.org/project/winregistry/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/winregistry.svg)](https://pypi.org/project/winregistry/)
+[![Python versions](https://img.shields.io/pypi/pyversions/winregistry.svg)](https://pypi.org/project/winregistry/)
+[![License](https://img.shields.io/pypi/l/winregistry.svg)](https://github.com/shpaker/winregistry/blob/main/LICENSE)
 
 A Python library for interacting with the Windows registry.
 

--- a/winregistry.py
+++ b/winregistry.py
@@ -892,7 +892,8 @@ class robot:  # noqa: N801
             cls.registry_key_should_exist(key_name)
         except FileNotFoundError:
             return
-        raise FileExistsError
+        msg = f"Registry key exists but should not: {key_name!r}"
+        raise AssertionError(msg)
 
     @staticmethod
     def registry_value_should_exist(
@@ -951,7 +952,8 @@ class robot:  # noqa: N801
             cls.registry_value_should_exist(key_name, value_name)
         except FileNotFoundError:
             return
-        raise FileExistsError
+        msg = f"Registry value exists but should not: key={key_name!r}, value={value_name!r}"
+        raise AssertionError(msg)
 
     @staticmethod
     def create_registry_key(


### PR DESCRIPTION
## Summary

Three critical fixes from the package audit:

- **C3** — `Robot Framework` keywords `Registry Key Should Not Exist` and `Registry Value Should Not Exist` now raise `AssertionError` (with descriptive message) instead of `FileExistsError`. Robot reports this as a proper failed assertion rather than an unexpected error.
- **C5** — `README` badges migrated from the deprecated `pypi.python.org` domain to `pypi.org/project/winregistry/`; added Python-versions and license badges for discoverability.
- **C1** — `.github/workflows/pypi.yml` now uses **PyPI Trusted Publisher (OIDC)** via `uv publish --trusted-publishing always`, with a dedicated `pypi` environment and `id-token: write` permission. Removes the long-lived `PYPI_PASS` token from the publish flow.

Out-of-scope per audit decisions:
- Python 3.8/3.9 support is kept as-is (known EOL risk, see audit doc).
- `sed`-based version substitution in `pypi.yml` is kept as-is.
- Important/nitpick findings (I*/N*) deferred to follow-up PRs.

## Required PyPI-side setup before next release

1. Go to https://pypi.org/manage/project/winregistry/settings/publishing/ → **Add a new publisher** → **GitHub**:
   - Owner: `shpaker`
   - Repository: `winregistry`
   - Workflow: `pypi.yml`
   - Environment: `pypi`
2. After the first successful publish via OIDC, the `PYPI_PASS` repository secret can be removed.

## Test plan

- [ ] CI: `robot.yml` workflow stays green on the full Python 3.8–3.14 matrix (Robot tests on Windows).
- [ ] On a real release, verify `pypi.yml` runs successfully and publishes via OIDC (no `PYPI_PASS` reference triggered).
- [ ] Visit the PyPI project page and confirm the new badges render and link to the correct URLs.
- [ ] On Windows, manually trigger the `Registry Key Should Not Exist` keyword against an existing key and confirm Robot reports a failed assertion (not error).

## Notes

`just lint` still reports 6 pre-existing `EM102`/`TRY003`/`UP032` warnings on lines unrelated to this change (the audit identified this as finding **I2** — CI does not currently run the linter). Those are intentionally not fixed here to keep the PR scoped to the three critical items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)